### PR TITLE
Add informational pages and account history

### DIFF
--- a/account.php
+++ b/account.php
@@ -1,0 +1,33 @@
+<?php
+include 'inc/lang.php';
+include 'navbar.php';
+$history = [];
+if (isset($_COOKIE['rankify_history'])) {
+    $history = json_decode($_COOKIE['rankify_history'], true);
+    if (!is_array($history)) $history = [];
+}
+?>
+<div class="container py-4">
+  <h1>Dein Profil</h1>
+  <p class="lead">Hier findest du eine spielerische &Uuml;bersicht deiner gespeicherten Ergebnisse.</p>
+  <?php if(empty($history)): ?>
+    <p>Noch keine Ergebnisse gespeichert.</p>
+  <?php else: ?>
+    <?php foreach(array_reverse($history) as $entry): ?>
+      <div class="card mb-3">
+        <div class="card-header d-flex justify-content-between">
+          <span>Set: <?=htmlspecialchars($entry['set'])?></span>
+          <span>🏆 <?=date('d.m.Y H:i', strtotime($entry['time']))?></span>
+        </div>
+        <ul class="list-group list-group-flush">
+          <?php $c=0; foreach($entry['scores'] as $id=>$score): if($c>=3) break; ?>
+            <li class="list-group-item">#<?=($c+1)?> <?=htmlspecialchars($id)?> <span class="badge bg-secondary float-end"><?=$score?></span></li>
+          <?php $c++; endforeach; ?>
+        </ul>
+      </div>
+    <?php endforeach; ?>
+  <?php endif; ?>
+</div>
+<?php include 'footer.php'; ?>
+</body>
+</html>

--- a/compare.php
+++ b/compare.php
@@ -260,5 +260,6 @@ include 'navbar.php';
         <a href="index.php" class="btn btn-secondary"><?=t('back_to_sets')?></a>
     </div>
 </div>
+<?php include 'footer.php'; ?>
 </body>
 </html>

--- a/contact.php
+++ b/contact.php
@@ -1,0 +1,50 @@
+<?php
+include 'inc/lang.php';
+if (file_exists('settings.php')) {
+    include 'settings.php';
+} else {
+    include 'settings.php.bak';
+}
+$sent = false;
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $msg = trim($_POST['message'] ?? '');
+    if ($name && $email && $msg) {
+        $headers = 'From: '.mb_encode_mimeheader($name).' <'.$email.'>';
+        @mail($ADMIN_EMAIL, 'Rankify Kontakt', $msg, $headers);
+        $sent = true;
+    } else {
+        $error = 'Bitte alle Felder ausfüllen.';
+    }
+}
+include 'navbar.php';
+?>
+<div class="container py-4">
+  <h1>Kontakt</h1>
+  <p class="lead">Fragen, Feedback oder wissenschaftliche Anregungen? Wir freuen uns auf deine Nachricht.</p>
+  <?php if($sent): ?>
+    <div class="alert alert-success">Deine Nachricht wurde verschickt.</div>
+  <?php else: ?>
+    <?php if($error): ?><div class="alert alert-danger"><?=$error?></div><?php endif; ?>
+    <form method="post">
+      <div class="mb-3">
+        <label for="name" class="form-label">Name</label>
+        <input type="text" class="form-control" id="name" name="name" required>
+      </div>
+      <div class="mb-3">
+        <label for="email" class="form-label">E-Mail</label>
+        <input type="email" class="form-control" id="email" name="email" required>
+      </div>
+      <div class="mb-3">
+        <label for="message" class="form-label">Nachricht</label>
+        <textarea class="form-control" id="message" name="message" rows="5" required></textarea>
+      </div>
+      <button type="submit" class="btn btn-primary">Senden</button>
+    </form>
+  <?php endif; ?>
+</div>
+<?php include 'footer.php'; ?>
+</body>
+</html>

--- a/faq.php
+++ b/faq.php
@@ -1,0 +1,31 @@
+<?php
+include 'inc/lang.php';
+include 'navbar.php';
+?>
+<div class="container py-4">
+  <h1>H&auml;ufige Fragen</h1>
+  <p class="lead">Hier findest du Antworten auf die wichtigsten Fragen rund um Rankify und die zugrunde liegenden Methoden.</p>
+  <div class="accordion" id="faqList">
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="q1"><button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#a1">Was ist Rankify?</button></h2>
+      <div id="a1" class="accordion-collapse collapse show" data-bs-parent="#faqList">
+        <div class="accordion-body">Rankify hilft dir, Priorit&auml;ten transparent zu machen. Durch Paarvergleiche ermittelst du spielerisch eine Rangfolge deiner Optionen.</div>
+      </div>
+    </div>
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="q2"><button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#a2">Wie funktioniert die Methode?</button></h2>
+      <div id="a2" class="accordion-collapse collapse" data-bs-parent="#faqList">
+        <div class="accordion-body">Unsere Berechnung orientiert sich an etablierten psychologischen Modellen des Paarvergleichs und nutzt Algorithmen wie Thurstone oder Bradley&ndash;Terry.</div>
+      </div>
+    </div>
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="q3"><button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#a3">Sind meine Daten sicher?</button></h2>
+      <div id="a3" class="accordion-collapse collapse" data-bs-parent="#faqList">
+        <div class="accordion-body">Ja. Es werden nur anonyme Daten gespeichert, um dir und anderen bessere Vergleiche zu erm&ouml;glichen. Details findest du in unserer Datenschutzerkl&auml;rung.</div>
+      </div>
+    </div>
+  </div>
+</div>
+<?php include 'footer.php'; ?>
+</body>
+</html>

--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,4 @@
+<footer class="text-center mt-5 mb-4">
+  <a href="legal-notice.php" class="mx-2">Impressum</a> |
+  <a href="privacy.php" class="mx-2">Datenschutz</a>
+</footer>

--- a/index.php
+++ b/index.php
@@ -61,6 +61,7 @@ include 'navbar.php';
 <div class="container py-4">
 
     <h1 class="mb-4"><?=t('sets_overview')?></h1>
+    <p class="lead">Nutze wissenschaftlich erprobte Paarvergleiche, um deine persönlichen Prioritäten herauszufinden. Wähle ein Set und starte direkt.</p>
 
     <?php if(empty($kartensets)): ?>
         <div class="alert alert-warning"><?=t('error_no_set')?></div>
@@ -81,8 +82,9 @@ include 'navbar.php';
             </div>
         <?php endforeach; ?>
         </div>
-    <?php endif; ?>
+<?php endif; ?>
 
 </div>
+<?php include 'footer.php'; ?>
 </body>
 </html>

--- a/legal-notice.php
+++ b/legal-notice.php
@@ -1,0 +1,21 @@
+<?php
+include 'inc/lang.php';
+if (file_exists('settings.php')) {
+    include 'settings.php';
+} else {
+    include 'settings.php.bak';
+}
+include 'navbar.php';
+?>
+<div class="container py-4">
+  <h1>Impressum</h1>
+  <p>Angaben gem&auml;&szlig; &sect;5 TMG</p>
+  <p><?=htmlspecialchars($ADMIN_NAME)?><br>
+     <?=nl2br(htmlspecialchars($ADMIN_ADDRESS))?><br>
+     E-Mail: <a href="mailto:<?=htmlspecialchars($ADMIN_EMAIL)?>"><?=htmlspecialchars($ADMIN_EMAIL)?></a></p>
+  <p>Verantwortlich f&uuml;r den Inhalt nach &sect; 55 Abs. 2 RStV:<br>
+     <?=htmlspecialchars($ADMIN_NAME)?>, <?=htmlspecialchars($ADMIN_ADDRESS)?></p>
+</div>
+<?php include 'footer.php'; ?>
+</body>
+</html>

--- a/privacy.php
+++ b/privacy.php
@@ -1,0 +1,17 @@
+<?php
+include 'inc/lang.php';
+if (file_exists('settings.php')) {
+    include 'settings.php';
+} else {
+    include 'settings.php.bak';
+}
+include 'navbar.php';
+?>
+<div class="container py-4">
+  <h1>Datenschutz</h1>
+  <p>Wir verarbeiten deine Daten ausschlie&szlig;lich zur Bereitstellung und Verbesserung von Rankify. Alle Angaben sind freiwillig und werden anonymisiert ausgewertet.</p>
+  <p>Bei Fragen erreichst du uns unter <a href="mailto:<?=htmlspecialchars($ADMIN_EMAIL)?>"><?=htmlspecialchars($ADMIN_EMAIL)?></a>.</p>
+</div>
+<?php include 'footer.php'; ?>
+</body>
+</html>

--- a/results.php
+++ b/results.php
@@ -181,6 +181,13 @@ foreach($antworten as $a) {
 arsort($scores);
 $maxScore = max($scores);
 
+// Ergebnisse im Cookie speichern
+$hist = isset($_COOKIE['rankify_history']) ? json_decode($_COOKIE['rankify_history'], true) : [];
+if (!is_array($hist)) $hist = [];
+$hist[] = ['time'=>date('c'),'set'=>$kartensetPfad,'scores'=>$scores];
+if (count($hist) > 10) $hist = array_slice($hist, -10);
+setcookie('rankify_history', json_encode($hist), time()+365*24*3600, '/');
+
 // Viele Figuren (SVG/Emoji)
 $figuren = [
     0=>"🦁", 1=>"🦉", 2=>"🐧", 3=>"🐢", 4=>"🐱", 5=>"🦊", 6=>"🐼", 7=>"🐸", 8=>"🦄", 9=>"🐯",
@@ -414,10 +421,11 @@ include 'navbar.php';
                         <span style="color:#666;font-size:.98em;">Abstimmungen: <?=implode(" · ", $countstr)?></span>
                     </div>
                 </div>
-            <?php endforeach; ?>
+<?php endforeach; ?>
         </div>
     <?php endif; ?>
 
 </div>
+<?php include 'footer.php'; ?>
 </body>
 </html>

--- a/settings.php.bak
+++ b/settings.php.bak
@@ -1,0 +1,5 @@
+<?php
+$ADMIN_EMAIL = 'admin@example.com';
+$ADMIN_NAME = 'Site Admin';
+$ADMIN_ADDRESS = 'Example Street 1, 12345 Sampletown';
+?>


### PR DESCRIPTION
## Summary
- add simple footer and link to legal notice & privacy pages
- implement an FAQ page
- implement contact form using settings
- add user account page showing results history
- store results history in a cookie
- update index intro text
- add settings.php.bak for admin data

## Testing
- `php -l account.php` *(fails: command not found)*
- `php -l contact.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441448e358832a9430c28f96708f3d