### PR TITLE
Improve contact security with email obfuscation and double opt‑in

### DIFF
--- a/assets/js/email.js
+++ b/assets/js/email.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('.obfuscated-email').forEach(function(el) {
+        var user = el.dataset.user;
+        var domain = el.dataset.domain;
+        if (!user || !domain) return;
+        var email = user + '@' + domain;
+        if (el.dataset.link) {
+            el.innerHTML = '<a href="mailto:' + email + '">' + email + '</a>';
+        } else {
+            el.textContent = email;
+        }
+    });
+});

--- a/contact.php
+++ b/contact.php
@@ -5,19 +5,62 @@ if (file_exists('settings.php')) {
 } else {
     include 'settings.php.bak';
 }
+include 'inc/email.php';
+session_start();
 $sent = false;
 $error = '';
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+$stage = '';
+
+// Bestätigungslink
+if (isset($_GET['confirm'])) {
+    $token = preg_replace('/[^a-zA-Z0-9]/','', $_GET['confirm']);
+    $file = __DIR__.'/data/contact/'.$token.'.json';
+    if (file_exists($file)) {
+        $data = json_decode(file_get_contents($file), true);
+        if ($data) {
+            $body  = '<p><strong>Name:</strong> '.htmlspecialchars($data['name']).'</p>';
+            $body .= '<p><strong>Email:</strong> '.htmlspecialchars($data['email']).'</p>';
+            $body .= '<p>'.nl2br(htmlspecialchars($data['message'])).'</p>';
+            send_email($ADMIN_EMAIL, 'Rankify Kontakt', $body);
+            unlink($file);
+            $sent = true;
+            $stage = 'confirmed';
+        }
+    }
+    if (!$sent) $error = 'Ungültiger oder abgelaufener Bestätigungslink.';
+}
+
+// Formularversand
+if (!$sent && $_SERVER['REQUEST_METHOD'] === 'POST') {
     $name = trim($_POST['name'] ?? '');
     $email = trim($_POST['email'] ?? '');
     $msg = trim($_POST['message'] ?? '');
-    if ($name && $email && $msg) {
-        $headers = 'From: '.mb_encode_mimeheader($name).' <'.$email.'>';
-        @mail($ADMIN_EMAIL, 'Rankify Kontakt', $msg, $headers);
+    $captcha = intval($_POST['captcha'] ?? 0);
+    if ($captcha !== ($_SESSION['captcha_result'] ?? -1)) {
+        $error = 'Captcha falsch.';
+    } elseif ($name && $email && $msg) {
+        $token = bin2hex(random_bytes(16));
+        @mkdir(__DIR__.'/data/contact', 0777, true);
+        file_put_contents(__DIR__.'/data/contact/'.$token.'.json', json_encode([
+            'name'=>$name,'email'=>$email,'message'=>$msg
+        ]));
+        $link = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS']!=='off'? 'https':'http').
+            '://'.$_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF'].'?confirm='.$token;
+        $body = '<p>Bitte bestätige deine Anfrage für Rankify, indem du auf folgenden Link klickst:</p>'.
+                '<p><a href="'.$link.'">Nachricht bestätigen</a></p>';
+        send_email($email, 'Bitte Kontakt bestätigen', $body);
         $sent = true;
+        $stage = 'waiting';
     } else {
         $error = 'Bitte alle Felder ausfüllen.';
     }
+}
+
+// Captcha erstellen
+if (!isset($_SESSION['captcha_result']) || $sent) {
+    $a = random_int(1,9); $b = random_int(1,9);
+    $_SESSION['captcha_result'] = $a + $b;
+    $_SESSION['captcha_question'] = "$a + $b = ?";
 }
 include 'navbar.php';
 ?>
@@ -25,7 +68,11 @@ include 'navbar.php';
   <h1>Kontakt</h1>
   <p class="lead">Fragen, Feedback oder wissenschaftliche Anregungen? Wir freuen uns auf deine Nachricht.</p>
   <?php if($sent): ?>
-    <div class="alert alert-success">Deine Nachricht wurde verschickt.</div>
+    <?php if($stage=='waiting'): ?>
+      <div class="alert alert-success">Bitte bestätige deine Nachricht über den Link in der zugesandten E-Mail.</div>
+    <?php else: ?>
+      <div class="alert alert-success">Deine Nachricht wurde verschickt.</div>
+    <?php endif; ?>
   <?php else: ?>
     <?php if($error): ?><div class="alert alert-danger"><?=$error?></div><?php endif; ?>
     <form method="post">
@@ -40,6 +87,10 @@ include 'navbar.php';
       <div class="mb-3">
         <label for="message" class="form-label">Nachricht</label>
         <textarea class="form-control" id="message" name="message" rows="5" required></textarea>
+      </div>
+      <div class="mb-3">
+        <label for="captcha" class="form-label"><?=$_SESSION['captcha_question']?></label>
+        <input type="number" class="form-control" id="captcha" name="captcha" required>
       </div>
       <button type="submit" class="btn btn-primary">Senden</button>
     </form>

--- a/inc/email.php
+++ b/inc/email.php
@@ -1,0 +1,16 @@
+<?php
+function email_template($title, $content) {
+    $style = 'body{background:#f5f7fb;font-family:Arial,sans-serif;color:#333;}'
+        .' .box{max-width:600px;margin:20px auto;background:#fff;border-radius:8px;'
+        .'padding:20px;border:1px solid #e2e2e2;}'
+        .' h1{color:#2E5BDA;font-size:1.4em;margin-top:0;}';
+    return "<!DOCTYPE html><html><head><meta charset='UTF-8'><style>{$style}</style></head><body><div class='box'><h1>Rankify</h1>".$content."<p style='font-size:12px;color:#666;margin-top:30px;'>Diese Mail wurde automatisch über Rankify erzeugt.</p></div></body></html>";
+}
+
+function send_email($to, $subject, $content) {
+    global $ADMIN_EMAIL;
+    $headers = "MIME-Version: 1.0\r\n";
+    $headers .= "Content-type: text/html; charset=UTF-8\r\n";
+    $headers .= "From: Rankify <{$ADMIN_EMAIL}>\r\n";
+    @mail($to, $subject, email_template($subject, $content), $headers);
+}

--- a/legal-notice.php
+++ b/legal-notice.php
@@ -10,9 +10,10 @@ include 'navbar.php';
 <div class="container py-4">
   <h1>Impressum</h1>
   <p>Angaben gem&auml;&szlig; &sect;5 TMG</p>
+  <?php list($u,$d)=explode('@',$ADMIN_EMAIL,2); ?>
   <p><?=htmlspecialchars($ADMIN_NAME)?><br>
      <?=nl2br(htmlspecialchars($ADMIN_ADDRESS))?><br>
-     E-Mail: <a href="mailto:<?=htmlspecialchars($ADMIN_EMAIL)?>"><?=htmlspecialchars($ADMIN_EMAIL)?></a></p>
+     E-Mail: <span class="obfuscated-email" data-user="<?=htmlspecialchars($u)?>" data-domain="<?=htmlspecialchars($d)?>" data-link="1">[email protected]</span></p>
   <p>Verantwortlich f&uuml;r den Inhalt nach &sect; 55 Abs. 2 RStV:<br>
      <?=htmlspecialchars($ADMIN_NAME)?>, <?=htmlspecialchars($ADMIN_ADDRESS)?></p>
 </div>

--- a/navbar.php
+++ b/navbar.php
@@ -68,6 +68,7 @@
   <link rel="stylesheet" href="assets/css/style.css">
   <script src="/assets/js/theme.js"></script>
   <script src="/assets/js/lang.js"></script>
+  <script src="/assets/js/email.js"></script>
 
 
   <!-- Progressive Enhancement / Accessibility (z.B. Schema.org, falls gewünscht) -->

--- a/privacy.php
+++ b/privacy.php
@@ -12,7 +12,8 @@ include 'navbar.php';
   <p>Der Schutz deiner Daten ist uns wichtig. Nachfolgend erkl&auml;ren wir, welche Informationen wir im Rahmen der Nutzung von Rankify verarbeiten und zu welchem Zweck dies geschieht.</p>
 
   <h3>Verantwortliche Stelle</h3>
-  <p><?=htmlspecialchars($ADMIN_NAME)?><br><?=nl2br(htmlspecialchars($ADMIN_ADDRESS))?><br>E-Mail: <a href="mailto:<?=htmlspecialchars($ADMIN_EMAIL)?>"><?=htmlspecialchars($ADMIN_EMAIL)?></a></p>
+  <?php list($u,$d)=explode('@',$ADMIN_EMAIL,2); ?>
+  <p><?=htmlspecialchars($ADMIN_NAME)?><br><?=nl2br(htmlspecialchars($ADMIN_ADDRESS))?><br>E-Mail: <span class="obfuscated-email" data-user="<?=htmlspecialchars($u)?>" data-domain="<?=htmlspecialchars($d)?>" data-link="1">[email protected]</span></p>
 
   <h3>Nutzungsdaten</h3>
   <p>Beim Aufruf dieser Webseite werden technisch bedingt Daten wie IP-Adresse und Zeitpunkt in Server-Logfiles gespeichert. Diese Daten ben&ouml;tigen wir, um den Dienst bereitzustellen und Angriffe abzuwehren. Eine Zusammenf&uuml;hrung mit anderen Daten erfolgt nicht.</p>
@@ -40,7 +41,8 @@ include 'navbar.php';
   <h3>Speicherdauer</h3>
   <p>Sitzungsdaten werden automatisch entfernt, sobald du das Browserfenster schlie&szlig;t oder das Set zur&uuml;cksetzt. Cookies bleiben bis zu einem Jahr gespeichert, k&ouml;nnen aber jederzeit von dir gel&ouml;scht werden.</p>
 
-  <p>Bei Fragen erreichst du uns unter <a href="mailto:<?=htmlspecialchars($ADMIN_EMAIL)?>"><?=htmlspecialchars($ADMIN_EMAIL)?></a>.</p>
+  <?php list($u2,$d2)=explode('@',$ADMIN_EMAIL,2); ?>
+  <p>Bei Fragen erreichst du uns unter <span class="obfuscated-email" data-user="<?=htmlspecialchars($u2)?>" data-domain="<?=htmlspecialchars($d2)?>" data-link="1">[email protected]</span>.</p>
 </div>
 <?php include 'footer.php'; ?>
 </body>


### PR DESCRIPTION
## Summary
- obfuscate admin e-mail on privacy and legal notice pages
- add JavaScript helper for displaying obfuscated emails
- integrate new HTML email template helper
- secure contact form with captcha and double opt-in e-mail confirmation

## Testing
- `php -l contact.php`
- `php -l legal-notice.php`
- `php -l privacy.php`
- `php -l inc/email.php`


------
https://chatgpt.com/codex/tasks/task_e_68441a47d8cc832ab146d5f37c226915