### PR TITLE
Add README and improve UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Rankify
+
+Rankify is a PHP-based web tool that helps you prioritize options through pairwise comparisons.
+Users rank items from predefined card sets. The application calculates scores using different
+models (e.g. Thurstone, Bradley–Terry) and presents an ordered list of your preferences.
+
+## Features
+* Simple pairwise comparison interface
+* Multiple statistical models
+* Profile page showing your last results
+* Export results as APA text, JSON, PNG or PDF
+
+## Installation
+1. Clone the repository.
+2. Ensure PHP 8+ is installed.
+3. Run a local server with `php -S localhost:8000` in the project directory.
+4. Open `http://localhost:8000` in your browser.
+
+No database is required; results are stored locally in the browser.
+
+## License
+This project is released under the MIT License. See `LICENSE` for details.

--- a/account.php
+++ b/account.php
@@ -21,22 +21,39 @@ function loadCardTitles($setPath) {
 }
 ?>
 <div class="container py-4">
-  <h1><?=t('account_title')?></h1>
+  <h1 class="d-flex justify-content-between align-items-center">
+      <span><?=t('account_title')?></span>
+      <?php if(!empty($history)): ?>
+        <button id="clearHistory" class="btn btn-outline-danger btn-sm"><?=t('account_clear_history') ?? 'Clear history'?></button>
+      <?php endif; ?>
+  </h1>
   <p class="lead"><?=t('account_lead')?></p>
   <?php if(empty($history)): ?>
     <p><?=t('account_no_results')?></p>
   <?php else: ?>
     <?php $hist = array_reverse($history); foreach($hist as $idx => $entry): ?>
-      <?php $cards = loadCardTitles($entry['set']); ?>
+      <?php
+        $cards = loadCardTitles($entry['set']);
+        $setDisplay = preg_replace('/(_[a-z]{2})?\.csv$/', '', basename($entry['set']));
+        $maxScore = max($entry['scores']);
+      ?>
       <div class="card mb-3">
         <div class="card-header d-flex justify-content-between">
-          <span>Set: <?=htmlspecialchars($entry['set'])?></span>
+          <span><?=htmlspecialchars($setDisplay)?></span>
           <span>🏆 <?=date('d.m.Y H:i', strtotime($entry['time']))?></span>
         </div>
         <ul class="list-group list-group-flush">
           <?php $c=0; foreach($entry['scores'] as $id=>$score): if($c>=3) break; ?>
-            <?php $title = $cards[$id]['title'] ?? $id; ?>
-            <li class="list-group-item">#<?=($c+1)?> <?=htmlspecialchars($title)?> <span class="badge bg-secondary float-end"><?=$score?></span></li>
+            <?php $title = $cards[$id]['title'] ?? $id; $percent = $maxScore ? round($score/$maxScore*100) : 0; ?>
+            <li class="list-group-item">
+              <div class="d-flex justify-content-between">
+                <span>#<?=($c+1)?> <?=htmlspecialchars($title)?></span>
+                <span class="badge bg-secondary"><?=$score?></span>
+              </div>
+              <div class="progress mt-1" style="height:6px;">
+                <div class="progress-bar" style="width:<?=$percent?>%"></div>
+              </div>
+            </li>
           <?php $c++; endforeach; ?>
         </ul>
         <div class="card-body">
@@ -53,6 +70,14 @@ function loadCardTitles($setPath) {
     <?php endforeach; ?>
   <?php endif; ?>
 </div>
+<script>
+document.getElementById('clearHistory')?.addEventListener('click', function(){
+    if(confirm('Delete all saved results?')) {
+        document.cookie = 'rankify_history=; path=/; max-age=0';
+        location.reload();
+    }
+});
+</script>
 <?php include 'footer.php'; ?>
 </body>
 </html>

--- a/assets/js/email.js
+++ b/assets/js/email.js
@@ -5,10 +5,11 @@ document.addEventListener('DOMContentLoaded', function() {
         var domain = el.dataset.domain;
         if (!user || !domain) return;
         var email = user + '@' + domain;
+        var display = user + ' [\u00e4t] ' + domain;
         if (el.dataset.link) {
-            el.innerHTML = '<a href="mailto:' + email + '">' + email + '</a>';
+            el.innerHTML = '<a href="mailto:' + email + '">' + display + '</a>';
         } else {
-            el.textContent = email;
+            el.textContent = display;
         }
     });
 

--- a/download.php
+++ b/download.php
@@ -15,6 +15,7 @@ if (!is_array($history) || !isset($history[$index])) {
 }
 $entry = $history[$index];
 $set   = $entry['set'];
+$setName = preg_replace('/(_[a-z]{2})?\.csv$/','', basename($set));
 $scores = $entry['scores'];
 $file = __DIR__.'/data/'.$set;
 if (!file_exists($file)) {
@@ -31,25 +32,26 @@ foreach ($rows as $r) {
 }
 // helper to create result text
 function build_text($cards, $scores) {
-    $out = ""; $rank = 1;
+    $parts = [];
+    $rank = 1;
     foreach ($scores as $id=>$score) {
         if (!isset($cards[$id])) continue;
         $c = $cards[$id];
-        $out .= $rank.'. '.$c['title'].' ('.$c['subtitle'].') – '.$score."\n";
+        $parts[] = "$rank. {$c['title']} ({$c['subtitle']}, Score=$score)";
         $rank++;
     }
-    return $out;
+    return 'The items were ranked as follows: '.implode('; ', $parts).'.';
 }
 $text = build_text($cards, $scores);
 switch($format) {
     case 'json':
         header('Content-Type: application/json');
-        header('Content-Disposition: attachment; filename="rankify_results.json"');
+        header('Content-Disposition: attachment; filename="'.$setName.'_results.json"');
         echo json_encode(['set'=>$set,'scores'=>$scores,'generated'=>date('c')], JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE);
         break;
     case 'apa':
         header('Content-Type: text/plain; charset=utf-8');
-        header('Content-Disposition: attachment; filename="rankify_results.txt"');
+        header('Content-Disposition: attachment; filename="'.$setName.'_results.txt"');
         echo $text;
         break;
     case 'png':
@@ -65,7 +67,7 @@ switch($format) {
             $y+=20;
         }
         header('Content-Type: image/png');
-        header('Content-Disposition: attachment; filename="rankify_results.png"');
+        header('Content-Disposition: attachment; filename="'.$setName.'_results.png"');
         imagepng($im);
         imagedestroy($im);
         break;
@@ -81,8 +83,8 @@ switch($format) {
             $pdf->Cell(0,8,$line,0,1);
         }
         header('Content-Type: application/pdf');
-        header('Content-Disposition: attachment; filename="rankify_results.pdf"');
-        $pdf->Output('D','rankify_results.pdf');
+        header('Content-Disposition: attachment; filename="'.$setName.'_results.pdf"');
+        $pdf->Output('D', $setName.'_results.pdf');
         break;
     default:
         http_response_code(400);

--- a/inc/lang.php
+++ b/inc/lang.php
@@ -345,6 +345,8 @@ References: %s",
     'account_no_results_en' => 'No results saved yet.',
     'account_highest_value_de' => 'Höchster Wert',
     'account_highest_value_en' => 'Highest value',
+    'account_clear_history_de' => 'Verlauf löschen',
+    'account_clear_history_en' => 'Clear history',
 
     // ------ Legal Notice ------
     'legal_title_de' => 'Impressum',


### PR DESCRIPTION
## Summary
- add project overview in README
- obfuscate email display with `[ät]`
- show nicer results in profile and allow clearing history
- rename download files to set name and update APA summary
- add translation strings for new button

## Testing
- `node -c assets/js/email.js`
- *No other tests could be run as PHP is not installed*


------
https://chatgpt.com/codex/tasks/task_e_6844373610a8832a9189bef33a0cd04e