### PR TITLE
Sanitize set parameter

### DIFF
--- a/compare.php
+++ b/compare.php
@@ -1,7 +1,12 @@
 <?php
 $WIEDERHOLUNGEN = 1;
 
-$kartensetPfad = $_GET['set'] ?? '';
+include 'inc/validate.php';
+$kartensetPfad = validate_set_path($_GET['set'] ?? '');
+if (!$kartensetPfad) {
+    http_response_code(400);
+    exit('Invalid set');
+}
 include 'inc/lang.php';
 include 'inc/kartenset_loader.php';
 include 'inc/session_handler.php';

--- a/download.php
+++ b/download.php
@@ -1,6 +1,7 @@
 <?php
 // Download helper for Rankify history entries
 include __DIR__.'/inc/lang.php';
+include __DIR__.'/inc/validate.php';
 if (!isset($_GET['index']) || !isset($_GET['format'])) {
     http_response_code(400);
     echo 'Missing parameters';
@@ -15,7 +16,12 @@ if (!is_array($history) || !isset($history[$index])) {
     exit;
 }
 $entry = $history[$index];
-$set   = $entry['set'];
+$set   = validate_set_path($entry['set']);
+if (!$set) {
+    http_response_code(400);
+    echo 'Invalid set';
+    exit;
+}
 $setName = preg_replace('/(_[a-z]{2})?\.csv$/','', basename($set));
 $scores = $entry['scores'];
 $file = __DIR__.'/data/'.$set;

--- a/inc/validate.php
+++ b/inc/validate.php
@@ -1,0 +1,14 @@
+<?php
+function validate_set_path($set) {
+    $allowedDirs = ['punkte', 'thurstone', 'bradleyterry'];
+    $set = str_replace('\\', '/', $set);
+    if (strpos($set, '..') !== false) return null;
+    $parts = explode('/', $set);
+    if (count($parts) !== 2) return null;
+    list($dir, $file) = $parts;
+    if (!in_array($dir, $allowedDirs, true)) return null;
+    $file = basename($file);
+    if (pathinfo($file, PATHINFO_EXTENSION) !== 'csv') return null;
+    return $dir.'/'.$file;
+}
+?>

--- a/results.php
+++ b/results.php
@@ -1,6 +1,11 @@
 <?php
 if (isset($_GET['export_json']) && !headers_sent()) {
-    $kartensetPfad = $_GET['set'] ?? '';
+    include 'inc/validate.php';
+    $kartensetPfad = validate_set_path($_GET['set'] ?? '');
+    if (!$kartensetPfad) {
+        http_response_code(400);
+        exit('Invalid set');
+    }
     include 'inc/lang.php';
     include 'inc/kartenset_loader.php';
     include 'inc/session_handler.php';
@@ -41,7 +46,12 @@ if (isset($_GET['export_json']) && !headers_sent()) {
     exit;
 }
 
-$kartensetPfad = $_GET['set'] ?? '';
+include_once 'inc/validate.php';
+$kartensetPfad = validate_set_path($_GET['set'] ?? '');
+if (!$kartensetPfad) {
+    http_response_code(400);
+    exit('Invalid set');
+}
 include 'inc/lang.php';
 include 'inc/kartenset_loader.php';
 include 'inc/session_handler.php';


### PR DESCRIPTION
## Summary
- restrict dataset selection paths by validating against allowed directories
- validate set path in results export and display logic
- validate set path when downloading result history entries

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68454f7e3ed0832ab0a9364596b08716