### PR TITLE
Improve norm tables and add demo generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ Confirmation links generated through the contact form are stored in `data/contac
 Run `php scripts/cleanup_tokens.php` periodically (e.g. daily via cron) to remove
 expired tokens.
 
+### Demo data
+To test the normative tables without collecting real responses you can
+generate example results:
+
+```bash
+php scripts/generate_demo_data.php
+```
+
+This populates `data/rankify.sqlite` with random scores for every card set so
+that the norm tables become visible.
+
 ## License
 This project is released under the MIT License. See `LICENSE` for details.
 

--- a/inc/lang.php
+++ b/inc/lang.php
@@ -251,6 +251,8 @@ References: %s",
     'norm_comparison_title_en' => 'Norm values for your group',
     'norm_public_title_de' => 'Öffentliche Statistik',
     'norm_public_title_en' => 'Public statistics',
+    'norm_not_available_de' => 'Noch nicht genügend Daten für Normwerte.',
+    'norm_not_available_en' => 'Not enough data yet for norm values.',
 
     // ------ FAQ ------
     'faq_title_de'  => 'Häufige Fragen',

--- a/results.php
+++ b/results.php
@@ -396,6 +396,10 @@ include 'navbar.php';
         <?php endforeach; ?>
         </ol>
     </div>
+    <?php else: ?>
+    <div class="norm-box mb-5 alert alert-info" role="alert">
+        <?=t('norm_not_available') ?? 'Noch keine Normwerte verfügbar.'?>
+    </div>
     <?php endif; ?>
     <?php if($normGlobal): ?>
     <div class="norm-box mb-5">

--- a/scripts/generate_demo_data.php
+++ b/scripts/generate_demo_data.php
@@ -1,0 +1,31 @@
+<?php
+require_once __DIR__.'/../inc/db.php';
+require_once __DIR__.'/../inc/kartenset_loader.php';
+
+$sets = getKartensets(__DIR__ . '/../data');
+
+foreach ($sets as $set) {
+    $file = $set['path'];
+    if (!file_exists($file)) continue;
+    $lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    array_shift($lines); // header
+    $ids = [];
+    foreach ($lines as $line) {
+        $parts = str_getcsv($line, ';');
+        if (count($parts) >= 3) $ids[] = $parts[0];
+    }
+    for ($i = 0; $i < NORM_MIN_COUNT; $i++) {
+        $scores = [];
+        foreach ($ids as $id) {
+            $scores[$id] = mt_rand(1, 100);
+        }
+        $demo = [
+            'alter' => mt_rand(18, 60),
+            'geschlecht' => (mt_rand(0,1) ? 'm' : 'w'),
+            'abschluss' => 'Bachelor'
+        ];
+        save_result_db($set['path'], $scores, $demo, false);
+    }
+}
+
+echo "Demo data generated in " . DB_FILE . "\n";


### PR DESCRIPTION
## Summary
- show a message when not enough norm data exists
- add translations for that message
- document demo data generation
- provide `generate_demo_data.php` script to populate the database

## Testing
- `php -l scripts/generate_demo_data.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68455c0e70ec832ab6adbd772cf99cd0