### PR TITLE
Fix demo data generation timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ generate example results:
 ```bash
 php scripts/generate_demo_data.php
 ```
+Run this command from the terminal rather than accessing the PHP file through the browser to avoid timeouts.
 
 This populates `data/rankify.sqlite` with random scores for every card set so
 that the norm tables become visible.

--- a/scripts/generate_demo_data.php
+++ b/scripts/generate_demo_data.php
@@ -1,8 +1,17 @@
 <?php
+// Only run from the command line to avoid web timeouts
+if (php_sapi_name() !== 'cli') {
+    header('HTTP/1.1 403 Forbidden');
+    echo "This script must be executed from the command line.";
+    exit;
+}
+
 require_once __DIR__.'/../inc/db.php';
 require_once __DIR__.'/../inc/kartenset_loader.php';
 
 $sets = getKartensets(__DIR__ . '/../data');
+$pdo = get_db();
+$pdo->beginTransaction();
 
 // Demographic categories used for generating example norms
 $genders = ['w', 'm', 'd'];
@@ -39,4 +48,5 @@ foreach ($sets as $set) {
     }
 }
 
+$pdo->commit();
 echo "Demo data generated in " . DB_FILE . "\n";


### PR DESCRIPTION
## Summary
- ensure generate_demo_data.php can only be run from CLI
- speed up demo data script using a database transaction
- note CLI usage in README

## Testing
- `php -l scripts/generate_demo_data.php`
- `php scripts/generate_demo_data.php`

------
https://chatgpt.com/codex/tasks/task_e_6845603c33a0832a9340b336ffa5d52d