### PR TITLE
Fix demo data script browser timeout

### DIFF
--- a/scripts/generate_demo_data.php
+++ b/scripts/generate_demo_data.php
@@ -2,6 +2,19 @@
 require_once __DIR__.'/../inc/db.php';
 require_once __DIR__.'/../inc/kartenset_loader.php';
 
+// Allow the script to run via web server without timing out
+if (PHP_SAPI !== 'cli') {
+    // Disable execution time limit when called from the browser
+    if (function_exists('set_time_limit')) {
+        set_time_limit(0);
+    }
+    header('Content-Type: text/plain; charset=utf-8');
+    // Send output immediately to avoid proxy timeouts
+    if (function_exists('ob_implicit_flush')) {
+        ob_implicit_flush(true);
+    }
+}
+
 $sets = getKartensets(__DIR__ . '/../data');
 
 // Demographic categories used for generating example norms
@@ -12,6 +25,7 @@ $ageGroups = [10,20,30,40,50,60];
 foreach ($sets as $set) {
     $file = $set['path'];
     if (!file_exists($file)) continue;
+    echo "Generating data for {$set['filename']}...\n";
     $lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
     array_shift($lines); // header
     $ids = [];
@@ -36,6 +50,10 @@ foreach ($sets as $set) {
                 }
             }
         }
+    }
+    echo "done\n";
+    if (PHP_SAPI !== 'cli') {
+        flush();
     }
 }
 


### PR DESCRIPTION
## Summary
- prevent timeouts when running `generate_demo_data.php` in a browser
- add small progress output and flush to avoid gateway timeouts

## Testing
- `php -l scripts/generate_demo_data.php`
- `php scripts/generate_demo_data.php | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6845618cd0f0832a8e50be89fbdb03c3