### PR TITLE
Enable web-triggered demo data generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ php scripts/generate_demo_data.php
 ```
 
 This populates `data/rankify.sqlite` with random scores for every card set so
-that the norm tables become visible.
+that the norm tables become visible. If you prefer to trigger the generation via
+your browser, simply open `scripts/generate_demo_data.php` in a web browser. The
+script immediately responds while the data is created in the background.
 
 ## License
 This project is released under the MIT License. See `LICENSE` for details.

--- a/scripts/generate_demo_data.php
+++ b/scripts/generate_demo_data.php
@@ -4,14 +4,23 @@ require_once __DIR__.'/../inc/kartenset_loader.php';
 
 // Allow the script to run via web server without timing out
 if (PHP_SAPI !== 'cli') {
-    // Disable execution time limit when called from the browser
+    // keep running even if the client disconnects
+    if (function_exists('ignore_user_abort')) {
+        ignore_user_abort(true);
+    }
     if (function_exists('set_time_limit')) {
         set_time_limit(0);
     }
     header('Content-Type: text/plain; charset=utf-8');
-    // Send output immediately to avoid proxy timeouts
+    echo "Starting demo data generation. This may take a while...\n";
     if (function_exists('ob_implicit_flush')) {
         ob_implicit_flush(true);
+    }
+    // finish the HTTP request so the browser doesn't time out
+    if (function_exists('fastcgi_finish_request')) {
+        fastcgi_finish_request();
+    } else {
+        flush();
     }
 }
 
@@ -60,3 +69,6 @@ foreach ($sets as $set) {
 }
 
 echo "Demo data generated in " . DB_FILE . "\n";
+if (PHP_SAPI !== 'cli') {
+    error_log('[Rankify] Demo data generation finished at '.date('c'));
+}


### PR DESCRIPTION
## Summary
- allow `generate_demo_data.php` to continue running after the HTTP request finishes
- document how to launch demo data generation from a browser

## Testing
- `php -l scripts/generate_demo_data.php`
- `find . -name '*.php' -print | xargs -I{} php -l {}`
- `php scripts/generate_demo_data.php` *(fails: terminated by user)*

------
https://chatgpt.com/codex/tasks/task_e_68456afcd2e4832ab68766acc44df218