### PR TITLE
Fix demo data path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,14 @@ php scripts/generate_demo_data.php
 ```
 
 This populates `data/rankify.sqlite` with random scores for every card set so
-that the norm tables become visible. If you prefer to trigger the generation via
-your browser, simply open `scripts/generate_demo_data.php` in a web browser. The
-script immediately responds while the data is created in the background.
+that the norm tables become visible. Make sure the PHP CLI is available and the
+`pdo_sqlite` extension is installed.
+
+If you prefer to trigger the generation via your browser, simply open
+`scripts/generate_demo_data.php` in a web browser. The script immediately
+responds while the data is created in the background. On some hosting systems
+the required shell commands may be disabled; in that case run the script from
+the command line instead.
 
 ## License
 This project is released under the MIT License. See `LICENSE` for details.

--- a/scripts/generate_demo_data.php
+++ b/scripts/generate_demo_data.php
@@ -76,8 +76,12 @@ foreach ($sets as $set) {
                         'geschlecht' => $gender,
                         'abschluss' => $edu
                     ];
+                    // Ensure the stored path matches the format used by the
+                    // application when saving real user results. Use realpath
+                    // to normalize the file path before stripping the data
+                    // directory prefix.
                     $dataRoot = realpath(__DIR__.'/../data');
-                    $relPath = str_replace($dataRoot.'/', '', $set['path']);
+                    $relPath = str_replace($dataRoot.'/', '', realpath($set['path']));
                     save_result_db($relPath, $scores, $demo, false);
                 }
             }


### PR DESCRIPTION
## Summary
- fix path computation in `generate_demo_data.php`
- expand README with CLI and sqlite extension requirements

## Testing
- `php -l scripts/generate_demo_data.php`
- `php scripts/generate_demo_data.php` *(partial run)*

------
https://chatgpt.com/codex/tasks/task_e_6845afff71b8832ab487d65c655f8f1c